### PR TITLE
Renaming proxy schema fields to avoid name collisions in the future

### DIFF
--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -29,7 +29,7 @@ async function makeGatewaySchema() {
   const wrappedProxySchema = wrapSchema({
     schema: proxySchema,
     transforms: [
-      new RenameTypes((name) => `proxy${capitalize(name)}`),
+      new RenameTypes((name) => `Proxy${capitalize(name)}`),
       new RenameRootFields((_, name) => `proxy${capitalize(name)}`),
     ],
   });

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -8,6 +8,7 @@ import { schema as web2Schema } from '@litentry/web2-subschema';
 import { schema as ipfsSchema } from '@litentry/ipfs-subschema';
 import makeRemoteExecutor from './makeRemoteExecutor';
 import config from './config';
+import { capitalize } from './utils';
 import { initSubstrateApi, SubstrateNetwork } from './substrateApi';
 
 async function makeGatewaySchema() {
@@ -27,20 +28,23 @@ async function makeGatewaySchema() {
 
   const wrappedProxySchema = wrapSchema({
     schema: proxySchema,
-    transforms: [new RenameTypes((name) => `proxy_${name}`)],
+    transforms: [
+      new RenameTypes((name) => `proxy${capitalize(name)}`),
+      new RenameRootFields((_, name) => `proxy${capitalize(name)}`),
+    ],
   });
   const wrappedIpfsSchema = wrapSchema({
     schema: ipfsSchema,
     transforms: [
       new RenameTypes((name) => `ipfs_${name}`),
-      new RenameRootFields((operation, name) => `ipfs_${name}`),
+      new RenameRootFields((_, name) => `ipfs_${name}`),
     ],
   });
   const wrappedWeb2Schema = wrapSchema({
     schema: web2Schema,
     transforms: [
       new RenameTypes((name) => `web2_${name}`),
-      new RenameRootFields((operation, name) => `web2_${name}`),
+      new RenameRootFields((_, name) => `web2_${name}`),
     ],
   });
 

--- a/api-gateway/src/utils.ts
+++ b/api-gateway/src/utils.ts
@@ -1,0 +1,3 @@
+export function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
Making the names to use camelCase and types PascalCase instead of underscore. (this is pure personal taste)
<img width="339" alt="Screenshot 2022-01-27 at 5 19 32 PM" src="https://user-images.githubusercontent.com/8374946/151399461-5497a608-e4c3-453f-97d9-447b9abae80c.png">

