### PR TITLE
Adding convictions to the proxy schema

### DIFF
--- a/subschemas/substrate-api-proxy/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-api-proxy/src/generated/resolvers-types.ts
@@ -1,22 +1,14 @@
-import {GraphQLResolveInfo} from 'graphql';
-import {PartialCouncilCandidate, PartialCouncilMember} from '../resolvers/Query/council';
-import {PartialRegistrar} from '../resolvers/Query/registrars';
-import {PartialProposalSecond} from '../resolvers/Query/democracy';
+import { GraphQLResolveInfo } from 'graphql';
+import { PartialCouncilCandidate, PartialCouncilMember } from '../resolvers/Query/council';
+import { PartialRegistrar } from '../resolvers/Query/registrars';
+import { PartialProposalSecond } from '../resolvers/Query/democracy';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends {[key: string]: unknown}> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-export type RequireFields<T, K extends keyof T> = {
-  [X in Exclude<keyof T, K>]?: T[X];
-} & {[P in K]-?: NonNullable<T[P]>};
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -98,6 +90,12 @@ export type CollectiveProposal = {
   callIndex: Scalars['String'];
   hash: Scalars['String'];
   votes: ProposalVotes;
+};
+
+export type Conviction = {
+  __typename?: 'Conviction';
+  text: Scalars['String'];
+  value: Scalars['Int'];
 };
 
 export type Council = {
@@ -305,6 +303,7 @@ export type Query = {
   bountiesSummary: BountiesSummary;
   bounty?: Maybe<Bounty>;
   chainInfo: ChainInfo;
+  convictions?: Maybe<Array<Conviction>>;
   council: Council;
   councilMotions: Array<CouncilMotion>;
   crowdloanSummary: CrowdloanSummary;
@@ -325,30 +324,37 @@ export type Query = {
   treasurySummary: TreasurySummary;
 };
 
+
 export type QueryAccountArgs = {
   address: Scalars['String'];
 };
+
 
 export type QueryBalanceArgs = {
   address: Scalars['String'];
   blockNumber?: InputMaybe<Scalars['Int']>;
 };
 
+
 export type QueryBountyArgs = {
   index: Scalars['String'];
 };
+
 
 export type QueryDemocracyProposalArgs = {
   index: Scalars['String'];
 };
 
+
 export type QueryDemocracyReferendumArgs = {
   index: Scalars['String'];
 };
 
+
 export type QueryParachainArgs = {
   id: Scalars['String'];
 };
+
 
 export type QueryTipArgs = {
   id: Scalars['String'];
@@ -445,39 +451,40 @@ export type ValidatorsGroup = {
   validators?: Maybe<Array<AccountInfo>>;
 };
 
+
+
 export type ResolverTypeWrapper<T> = Promise<T> | T;
+
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  | ResolverFn<TResult, TParent, TContext, TArgs>
-  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
 export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{[key in TKey]: TResult}, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, {[key in TKey]: TResult}, TContext, TArgs>;
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -496,14 +503,10 @@ export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TCo
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
-  obj: T,
-  context: TContext,
-  info: GraphQLResolveInfo,
-) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
@@ -512,7 +515,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -527,21 +530,11 @@ export type ResolversTypes = {
   BountyStatus: ResolverTypeWrapper<BountyStatus>;
   ChainInfo: ResolverTypeWrapper<ChainInfo>;
   CollectiveProposal: ResolverTypeWrapper<CollectiveProposal>;
-  Council: ResolverTypeWrapper<
-    Omit<Council, 'candidates' | 'members' | 'primeMember' | 'runnersUp'> & {
-      candidates: Array<ResolversTypes['CouncilCandidate']>;
-      members: Array<ResolversTypes['CouncilMember']>;
-      primeMember?: Maybe<ResolversTypes['CouncilMember']>;
-      runnersUp: Array<ResolversTypes['CouncilMember']>;
-    }
-  >;
+  Conviction: ResolverTypeWrapper<Conviction>;
+  Council: ResolverTypeWrapper<Omit<Council, 'candidates' | 'members' | 'primeMember' | 'runnersUp'> & { candidates: Array<ResolversTypes['CouncilCandidate']>, members: Array<ResolversTypes['CouncilMember']>, primeMember?: Maybe<ResolversTypes['CouncilMember']>, runnersUp: Array<ResolversTypes['CouncilMember']> }>;
   CouncilCandidate: ResolverTypeWrapper<PartialCouncilCandidate>;
   CouncilMember: ResolverTypeWrapper<PartialCouncilMember>;
-  CouncilMotion: ResolverTypeWrapper<
-    Omit<CouncilMotion, 'proposal'> & {
-      proposal: ResolversTypes['MotionProposal'];
-    }
-  >;
+  CouncilMotion: ResolverTypeWrapper<Omit<CouncilMotion, 'proposal'> & { proposal: ResolversTypes['MotionProposal'] }>;
   CrowdloanSummary: ResolverTypeWrapper<CrowdloanSummary>;
   DemocracySummary: ResolverTypeWrapper<DemocracySummary>;
   DeriveAccountRegistration: ResolverTypeWrapper<DeriveAccountRegistration>;
@@ -553,31 +546,18 @@ export type ResolversTypes = {
   Lease: ResolverTypeWrapper<Lease>;
   LeasePeriod: ResolverTypeWrapper<LeasePeriod>;
   ModuleElection: ResolverTypeWrapper<ModuleElection>;
-  MotionProposal: ResolverTypeWrapper<
-    Omit<MotionProposal, 'args'> & {
-      args: Array<ResolversTypes['ProposalArg']>;
-    }
-  >;
+  MotionProposal: ResolverTypeWrapper<Omit<MotionProposal, 'args'> & { args: Array<ResolversTypes['ProposalArg']> }>;
   MotionVotes: ResolverTypeWrapper<MotionVotes>;
   PalletProposal: ResolverTypeWrapper<PalletProposal>;
   Parachain: ResolverTypeWrapper<Parachain>;
   ParachainsInfo: ResolverTypeWrapper<ParachainsInfo>;
-  Proposal: ResolverTypeWrapper<
-    Omit<Proposal, 'args' | 'seconds'> & {
-      args: Array<ResolversTypes['ProposalArg']>;
-      seconds: Array<ResolversTypes['ProposalSecond']>;
-    }
-  >;
-  ProposalArg: ResolverTypeWrapper<
-    Omit<ProposalArg, 'subCalls'> & {
-      subCalls?: Maybe<Array<Maybe<ResolversTypes['Proposal']>>>;
-    }
-  >;
+  Proposal: ResolverTypeWrapper<Omit<Proposal, 'args' | 'seconds'> & { args: Array<ResolversTypes['ProposalArg']>, seconds: Array<ResolversTypes['ProposalSecond']> }>;
+  ProposalArg: ResolverTypeWrapper<Omit<ProposalArg, 'subCalls'> & { subCalls?: Maybe<Array<Maybe<ResolversTypes['Proposal']>>> }>;
   ProposalSecond: ResolverTypeWrapper<PartialProposalSecond>;
   ProposalVotes: ResolverTypeWrapper<ProposalVotes>;
   Proposer: ResolverTypeWrapper<Proposer>;
   Query: ResolverTypeWrapper<{}>;
-  Referendum: ResolverTypeWrapper<Omit<Referendum, 'args'> & {args: Array<ResolversTypes['ProposalArg']>}>;
+  Referendum: ResolverTypeWrapper<Omit<Referendum, 'args'> & { args: Array<ResolversTypes['ProposalArg']> }>;
   Registrar: ResolverTypeWrapper<PartialRegistrar>;
   RegistrationJudgement: ResolverTypeWrapper<RegistrationJudgement>;
   String: ResolverTypeWrapper<Scalars['String']>;
@@ -602,17 +582,11 @@ export type ResolversParentTypes = {
   BountyStatus: BountyStatus;
   ChainInfo: ChainInfo;
   CollectiveProposal: CollectiveProposal;
-  Council: Omit<Council, 'candidates' | 'members' | 'primeMember' | 'runnersUp'> & {
-    candidates: Array<ResolversParentTypes['CouncilCandidate']>;
-    members: Array<ResolversParentTypes['CouncilMember']>;
-    primeMember?: Maybe<ResolversParentTypes['CouncilMember']>;
-    runnersUp: Array<ResolversParentTypes['CouncilMember']>;
-  };
+  Conviction: Conviction;
+  Council: Omit<Council, 'candidates' | 'members' | 'primeMember' | 'runnersUp'> & { candidates: Array<ResolversParentTypes['CouncilCandidate']>, members: Array<ResolversParentTypes['CouncilMember']>, primeMember?: Maybe<ResolversParentTypes['CouncilMember']>, runnersUp: Array<ResolversParentTypes['CouncilMember']> };
   CouncilCandidate: PartialCouncilCandidate;
   CouncilMember: PartialCouncilMember;
-  CouncilMotion: Omit<CouncilMotion, 'proposal'> & {
-    proposal: ResolversParentTypes['MotionProposal'];
-  };
+  CouncilMotion: Omit<CouncilMotion, 'proposal'> & { proposal: ResolversParentTypes['MotionProposal'] };
   CrowdloanSummary: CrowdloanSummary;
   DemocracySummary: DemocracySummary;
   DeriveAccountRegistration: DeriveAccountRegistration;
@@ -624,27 +598,18 @@ export type ResolversParentTypes = {
   Lease: Lease;
   LeasePeriod: LeasePeriod;
   ModuleElection: ModuleElection;
-  MotionProposal: Omit<MotionProposal, 'args'> & {
-    args: Array<ResolversParentTypes['ProposalArg']>;
-  };
+  MotionProposal: Omit<MotionProposal, 'args'> & { args: Array<ResolversParentTypes['ProposalArg']> };
   MotionVotes: MotionVotes;
   PalletProposal: PalletProposal;
   Parachain: Parachain;
   ParachainsInfo: ParachainsInfo;
-  Proposal: Omit<Proposal, 'args' | 'seconds'> & {
-    args: Array<ResolversParentTypes['ProposalArg']>;
-    seconds: Array<ResolversParentTypes['ProposalSecond']>;
-  };
-  ProposalArg: Omit<ProposalArg, 'subCalls'> & {
-    subCalls?: Maybe<Array<Maybe<ResolversParentTypes['Proposal']>>>;
-  };
+  Proposal: Omit<Proposal, 'args' | 'seconds'> & { args: Array<ResolversParentTypes['ProposalArg']>, seconds: Array<ResolversParentTypes['ProposalSecond']> };
+  ProposalArg: Omit<ProposalArg, 'subCalls'> & { subCalls?: Maybe<Array<Maybe<ResolversParentTypes['Proposal']>>> };
   ProposalSecond: PartialProposalSecond;
   ProposalVotes: ProposalVotes;
   Proposer: Proposer;
   Query: {};
-  Referendum: Omit<Referendum, 'args'> & {
-    args: Array<ResolversParentTypes['ProposalArg']>;
-  };
+  Referendum: Omit<Referendum, 'args'> & { args: Array<ResolversParentTypes['ProposalArg']> };
   Registrar: PartialRegistrar;
   RegistrationJudgement: RegistrationJudgement;
   String: Scalars['String'];
@@ -657,29 +622,20 @@ export type ResolversParentTypes = {
   ValidatorsGroup: ValidatorsGroup;
 };
 
-export type AccountResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Account'] = ResolversParentTypes['Account'],
-> = {
+export type AccountResolvers<ContextType = any, ParentType extends ResolversParentTypes['Account'] = ResolversParentTypes['Account']> = {
   address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   display?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   registration?: Resolver<ResolversTypes['DeriveAccountRegistration'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type AccountInfoResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['AccountInfo'] = ResolversParentTypes['AccountInfo'],
-> = {
+export type AccountInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['AccountInfo'] = ResolversParentTypes['AccountInfo']> = {
   account?: Resolver<ResolversTypes['Account'], ParentType, ContextType>;
   address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type BalanceResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Balance'] = ResolversParentTypes['Balance'],
-> = {
+export type BalanceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Balance'] = ResolversParentTypes['Balance']> = {
   consumers?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   data?: Resolver<ResolversTypes['BalanceData'], ParentType, ContextType>;
   nonce?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -688,10 +644,7 @@ export type BalanceResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type BalanceDataResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['BalanceData'] = ResolversParentTypes['BalanceData'],
-> = {
+export type BalanceDataResolvers<ContextType = any, ParentType extends ResolversParentTypes['BalanceData'] = ResolversParentTypes['BalanceData']> = {
   feeFrozen?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   free?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   miscFrozen?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
@@ -699,10 +652,7 @@ export type BalanceDataResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type BountiesSummaryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['BountiesSummary'] = ResolversParentTypes['BountiesSummary'],
-> = {
+export type BountiesSummaryResolvers<ContextType = any, ParentType extends ResolversParentTypes['BountiesSummary'] = ResolversParentTypes['BountiesSummary']> = {
   activeBounties?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   bountyCount?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   pastBounties?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -711,10 +661,7 @@ export type BountiesSummaryResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type BountyResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Bounty'] = ResolversParentTypes['Bounty'],
-> = {
+export type BountyResolvers<ContextType = any, ParentType extends ResolversParentTypes['Bounty'] = ResolversParentTypes['Bounty']> = {
   bond?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   bountyStatus?: Resolver<Maybe<ResolversTypes['BountyStatus']>, ParentType, ContextType>;
   curatorDeposit?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -726,10 +673,7 @@ export type BountyResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type BountyStatusResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['BountyStatus'] = ResolversParentTypes['BountyStatus'],
-> = {
+export type BountyStatusResolvers<ContextType = any, ParentType extends ResolversParentTypes['BountyStatus'] = ResolversParentTypes['BountyStatus']> = {
   beneficiary?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   curator?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -738,30 +682,27 @@ export type BountyStatusResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ChainInfoResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ChainInfo'] = ResolversParentTypes['ChainInfo'],
-> = {
+export type ChainInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['ChainInfo'] = ResolversParentTypes['ChainInfo']> = {
   chain?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   nodeName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   nodeVersion?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CollectiveProposalResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CollectiveProposal'] = ResolversParentTypes['CollectiveProposal'],
-> = {
+export type CollectiveProposalResolvers<ContextType = any, ParentType extends ResolversParentTypes['CollectiveProposal'] = ResolversParentTypes['CollectiveProposal']> = {
   callIndex?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   votes?: Resolver<ResolversTypes['ProposalVotes'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CouncilResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Council'] = ResolversParentTypes['Council'],
-> = {
+export type ConvictionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Conviction'] = ResolversParentTypes['Conviction']> = {
+  text?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  value?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CouncilResolvers<ContextType = any, ParentType extends ResolversParentTypes['Council'] = ResolversParentTypes['Council']> = {
   candidates?: Resolver<Array<ResolversTypes['CouncilCandidate']>, ParentType, ContextType>;
   desiredRunnersUp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   desiredSeats?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -772,19 +713,13 @@ export type CouncilResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CouncilCandidateResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CouncilCandidate'] = ResolversParentTypes['CouncilCandidate'],
-> = {
+export type CouncilCandidateResolvers<ContextType = any, ParentType extends ResolversParentTypes['CouncilCandidate'] = ResolversParentTypes['CouncilCandidate']> = {
   account?: Resolver<ResolversTypes['Account'], ParentType, ContextType>;
   address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CouncilMemberResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CouncilMember'] = ResolversParentTypes['CouncilMember'],
-> = {
+export type CouncilMemberResolvers<ContextType = any, ParentType extends ResolversParentTypes['CouncilMember'] = ResolversParentTypes['CouncilMember']> = {
   account?: Resolver<ResolversTypes['Account'], ParentType, ContextType>;
   address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   backing?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -792,20 +727,14 @@ export type CouncilMemberResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CouncilMotionResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CouncilMotion'] = ResolversParentTypes['CouncilMotion'],
-> = {
+export type CouncilMotionResolvers<ContextType = any, ParentType extends ResolversParentTypes['CouncilMotion'] = ResolversParentTypes['CouncilMotion']> = {
   hash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   proposal?: Resolver<ResolversTypes['MotionProposal'], ParentType, ContextType>;
   votes?: Resolver<Maybe<ResolversTypes['MotionVotes']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CrowdloanSummaryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CrowdloanSummary'] = ResolversParentTypes['CrowdloanSummary'],
-> = {
+export type CrowdloanSummaryResolvers<ContextType = any, ParentType extends ResolversParentTypes['CrowdloanSummary'] = ResolversParentTypes['CrowdloanSummary']> = {
   activeCap?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   activeProgress?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   activeRaised?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -820,10 +749,7 @@ export type CrowdloanSummaryResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type DemocracySummaryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['DemocracySummary'] = ResolversParentTypes['DemocracySummary'],
-> = {
+export type DemocracySummaryResolvers<ContextType = any, ParentType extends ResolversParentTypes['DemocracySummary'] = ResolversParentTypes['DemocracySummary']> = {
   activeProposals?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   activeReferendums?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   launchPeriod?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -832,10 +758,7 @@ export type DemocracySummaryResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type DeriveAccountRegistrationResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['DeriveAccountRegistration'] = ResolversParentTypes['DeriveAccountRegistration'],
-> = {
+export type DeriveAccountRegistrationResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeriveAccountRegistration'] = ResolversParentTypes['DeriveAccountRegistration']> = {
   display?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayParent?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -849,10 +772,7 @@ export type DeriveAccountRegistrationResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type EventResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Event'] = ResolversParentTypes['Event'],
-> = {
+export type EventResolvers<ContextType = any, ParentType extends ResolversParentTypes['Event'] = ResolversParentTypes['Event']> = {
   blockNumber?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -860,10 +780,7 @@ export type EventResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type IdentityJudgementResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['IdentityJudgement'] = ResolversParentTypes['IdentityJudgement'],
-> = {
+export type IdentityJudgementResolvers<ContextType = any, ParentType extends ResolversParentTypes['IdentityJudgement'] = ResolversParentTypes['IdentityJudgement']> = {
   isErroneous?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   isFeePaid?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   isKnownGood?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
@@ -874,19 +791,13 @@ export type IdentityJudgementResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type LeaseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Lease'] = ResolversParentTypes['Lease'],
-> = {
+export type LeaseResolvers<ContextType = any, ParentType extends ResolversParentTypes['Lease'] = ResolversParentTypes['Lease']> = {
   blockTime?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   period?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type LeasePeriodResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['LeasePeriod'] = ResolversParentTypes['LeasePeriod'],
-> = {
+export type LeasePeriodResolvers<ContextType = any, ParentType extends ResolversParentTypes['LeasePeriod'] = ResolversParentTypes['LeasePeriod']> = {
   currentLease?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   progressPercent?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   remainder?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -894,19 +805,13 @@ export type LeasePeriodResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ModuleElectionResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ModuleElection'] = ResolversParentTypes['ModuleElection'],
-> = {
+export type ModuleElectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['ModuleElection'] = ResolversParentTypes['ModuleElection']> = {
   hasElections?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   module?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type MotionProposalResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['MotionProposal'] = ResolversParentTypes['MotionProposal'],
-> = {
+export type MotionProposalResolvers<ContextType = any, ParentType extends ResolversParentTypes['MotionProposal'] = ResolversParentTypes['MotionProposal']> = {
   args?: Resolver<Array<ResolversTypes['ProposalArg']>, ParentType, ContextType>;
   hash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   method?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -914,10 +819,7 @@ export type MotionProposalResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type MotionVotesResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['MotionVotes'] = ResolversParentTypes['MotionVotes'],
-> = {
+export type MotionVotesResolvers<ContextType = any, ParentType extends ResolversParentTypes['MotionVotes'] = ResolversParentTypes['MotionVotes']> = {
   ayes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   end?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   index?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -926,10 +828,7 @@ export type MotionVotesResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type PalletProposalResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['PalletProposal'] = ResolversParentTypes['PalletProposal'],
-> = {
+export type PalletProposalResolvers<ContextType = any, ParentType extends ResolversParentTypes['PalletProposal'] = ResolversParentTypes['PalletProposal']> = {
   beneficiary?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   bond?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   proposer?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -937,10 +836,7 @@ export type PalletProposalResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ParachainResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Parachain'] = ResolversParentTypes['Parachain'],
-> = {
+export type ParachainResolvers<ContextType = any, ParentType extends ResolversParentTypes['Parachain'] = ResolversParentTypes['Parachain']> = {
   homepage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   lastBackedBlock?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -953,10 +849,7 @@ export type ParachainResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ParachainsInfoResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ParachainsInfo'] = ResolversParentTypes['ParachainsInfo'],
-> = {
+export type ParachainsInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['ParachainsInfo'] = ResolversParentTypes['ParachainsInfo']> = {
   leasePeriod?: Resolver<ResolversTypes['LeasePeriod'], ParentType, ContextType>;
   parachainsCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   parathreadsCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -964,10 +857,7 @@ export type ParachainsInfoResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ProposalResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Proposal'] = ResolversParentTypes['Proposal'],
-> = {
+export type ProposalResolvers<ContextType = any, ParentType extends ResolversParentTypes['Proposal'] = ResolversParentTypes['Proposal']> = {
   args?: Resolver<Array<ResolversTypes['ProposalArg']>, ParentType, ContextType>;
   balance?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   hash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -980,10 +870,7 @@ export type ProposalResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ProposalArgResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ProposalArg'] = ResolversParentTypes['ProposalArg'],
-> = {
+export type ProposalArgResolvers<ContextType = any, ParentType extends ResolversParentTypes['ProposalArg'] = ResolversParentTypes['ProposalArg']> = {
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   subCalls?: Resolver<Maybe<Array<Maybe<ResolversTypes['Proposal']>>>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -991,19 +878,13 @@ export type ProposalArgResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ProposalSecondResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ProposalSecond'] = ResolversParentTypes['ProposalSecond'],
-> = {
+export type ProposalSecondResolvers<ContextType = any, ParentType extends ResolversParentTypes['ProposalSecond'] = ResolversParentTypes['ProposalSecond']> = {
   account?: Resolver<ResolversTypes['Account'], ParentType, ContextType>;
   address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ProposalVotesResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ProposalVotes'] = ResolversParentTypes['ProposalVotes'],
-> = {
+export type ProposalVotesResolvers<ContextType = any, ParentType extends ResolversParentTypes['ProposalVotes'] = ResolversParentTypes['ProposalVotes']> = {
   ayes?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   end?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   index?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1012,56 +893,31 @@ export type ProposalVotesResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ProposerResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Proposer'] = ResolversParentTypes['Proposer'],
-> = {
+export type ProposerResolvers<ContextType = any, ParentType extends ResolversParentTypes['Proposer'] = ResolversParentTypes['Proposer']> = {
   account?: Resolver<Maybe<ResolversTypes['Account']>, ParentType, ContextType>;
   address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type QueryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query'],
-> = {
-  account?: Resolver<
-    Maybe<ResolversTypes['Account']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryAccountArgs, 'address'>
-  >;
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  account?: Resolver<Maybe<ResolversTypes['Account']>, ParentType, ContextType, RequireFields<QueryAccountArgs, 'address'>>;
   balance?: Resolver<ResolversTypes['Balance'], ParentType, ContextType, RequireFields<QueryBalanceArgs, 'address'>>;
   bounties?: Resolver<Array<ResolversTypes['Bounty']>, ParentType, ContextType>;
   bountiesSummary?: Resolver<ResolversTypes['BountiesSummary'], ParentType, ContextType>;
   bounty?: Resolver<Maybe<ResolversTypes['Bounty']>, ParentType, ContextType, RequireFields<QueryBountyArgs, 'index'>>;
   chainInfo?: Resolver<ResolversTypes['ChainInfo'], ParentType, ContextType>;
+  convictions?: Resolver<Maybe<Array<ResolversTypes['Conviction']>>, ParentType, ContextType>;
   council?: Resolver<ResolversTypes['Council'], ParentType, ContextType>;
   councilMotions?: Resolver<Array<ResolversTypes['CouncilMotion']>, ParentType, ContextType>;
   crowdloanSummary?: Resolver<ResolversTypes['CrowdloanSummary'], ParentType, ContextType>;
-  democracyProposal?: Resolver<
-    Maybe<ResolversTypes['Proposal']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryDemocracyProposalArgs, 'index'>
-  >;
+  democracyProposal?: Resolver<Maybe<ResolversTypes['Proposal']>, ParentType, ContextType, RequireFields<QueryDemocracyProposalArgs, 'index'>>;
   democracyProposals?: Resolver<Array<ResolversTypes['Proposal']>, ParentType, ContextType>;
-  democracyReferendum?: Resolver<
-    Maybe<ResolversTypes['Referendum']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryDemocracyReferendumArgs, 'index'>
-  >;
+  democracyReferendum?: Resolver<Maybe<ResolversTypes['Referendum']>, ParentType, ContextType, RequireFields<QueryDemocracyReferendumArgs, 'index'>>;
   democracyReferendums?: Resolver<Array<ResolversTypes['Referendum']>, ParentType, ContextType>;
   democracySummary?: Resolver<ResolversTypes['DemocracySummary'], ParentType, ContextType>;
   events?: Resolver<Array<ResolversTypes['Event']>, ParentType, ContextType>;
   moduleElection?: Resolver<ResolversTypes['ModuleElection'], ParentType, ContextType>;
-  parachain?: Resolver<
-    Maybe<ResolversTypes['Parachain']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryParachainArgs, 'id'>
-  >;
+  parachain?: Resolver<Maybe<ResolversTypes['Parachain']>, ParentType, ContextType, RequireFields<QueryParachainArgs, 'id'>>;
   parachains?: Resolver<Maybe<Array<ResolversTypes['Parachain']>>, ParentType, ContextType>;
   parachainsInfo?: Resolver<ResolversTypes['ParachainsInfo'], ParentType, ContextType>;
   registrars?: Resolver<Maybe<Array<ResolversTypes['Registrar']>>, ParentType, ContextType>;
@@ -1071,10 +927,7 @@ export type QueryResolvers<
   treasurySummary?: Resolver<ResolversTypes['TreasurySummary'], ParentType, ContextType>;
 };
 
-export type ReferendumResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Referendum'] = ResolversParentTypes['Referendum'],
-> = {
+export type ReferendumResolvers<ContextType = any, ParentType extends ResolversParentTypes['Referendum'] = ResolversParentTypes['Referendum']> = {
   activatePeriod?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   args?: Resolver<Array<ResolversTypes['ProposalArg']>, ParentType, ContextType>;
   endPeriod?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1090,10 +943,7 @@ export type ReferendumResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type RegistrarResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Registrar'] = ResolversParentTypes['Registrar'],
-> = {
+export type RegistrarResolvers<ContextType = any, ParentType extends ResolversParentTypes['Registrar'] = ResolversParentTypes['Registrar']> = {
   account?: Resolver<Maybe<ResolversTypes['Account']>, ParentType, ContextType>;
   address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   fee?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1102,29 +952,20 @@ export type RegistrarResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type RegistrationJudgementResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['RegistrationJudgement'] = ResolversParentTypes['RegistrationJudgement'],
-> = {
+export type RegistrationJudgementResolvers<ContextType = any, ParentType extends ResolversParentTypes['RegistrationJudgement'] = ResolversParentTypes['RegistrationJudgement']> = {
   index?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   judgement?: Resolver<Maybe<ResolversTypes['IdentityJudgement']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type TermProgressResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['TermProgress'] = ResolversParentTypes['TermProgress'],
-> = {
+export type TermProgressResolvers<ContextType = any, ParentType extends ResolversParentTypes['TermProgress'] = ResolversParentTypes['TermProgress']> = {
   percentage?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   termDuration?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   termLeft?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type TipResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Tip'] = ResolversParentTypes['Tip'],
-> = {
+export type TipResolvers<ContextType = any, ParentType extends ResolversParentTypes['Tip'] = ResolversParentTypes['Tip']> = {
   closes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   deposit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   finder?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1135,19 +976,13 @@ export type TipResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type TreasuryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Treasury'] = ResolversParentTypes['Treasury'],
-> = {
+export type TreasuryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Treasury'] = ResolversParentTypes['Treasury']> = {
   approvals?: Resolver<Array<ResolversTypes['TreasuryProposal']>, ParentType, ContextType>;
   proposals?: Resolver<Array<ResolversTypes['TreasuryProposal']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type TreasuryBalanceResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['TreasuryBalance'] = ResolversParentTypes['TreasuryBalance'],
-> = {
+export type TreasuryBalanceResolvers<ContextType = any, ParentType extends ResolversParentTypes['TreasuryBalance'] = ResolversParentTypes['TreasuryBalance']> = {
   accountId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   accountNonce?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   freeBalance?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -1158,20 +993,14 @@ export type TreasuryBalanceResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type TreasuryProposalResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['TreasuryProposal'] = ResolversParentTypes['TreasuryProposal'],
-> = {
+export type TreasuryProposalResolvers<ContextType = any, ParentType extends ResolversParentTypes['TreasuryProposal'] = ResolversParentTypes['TreasuryProposal']> = {
   councils?: Resolver<Array<ResolversTypes['CollectiveProposal']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   proposal?: Resolver<ResolversTypes['PalletProposal'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type TreasurySummaryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['TreasurySummary'] = ResolversParentTypes['TreasurySummary'],
-> = {
+export type TreasurySummaryResolvers<ContextType = any, ParentType extends ResolversParentTypes['TreasurySummary'] = ResolversParentTypes['TreasurySummary']> = {
   activeProposals?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   approvedProposals?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   burn?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1181,10 +1010,7 @@ export type TreasurySummaryResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ValidatorsGroupResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ValidatorsGroup'] = ResolversParentTypes['ValidatorsGroup'],
-> = {
+export type ValidatorsGroupResolvers<ContextType = any, ParentType extends ResolversParentTypes['ValidatorsGroup'] = ResolversParentTypes['ValidatorsGroup']> = {
   groupIndex?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   validators?: Resolver<Maybe<Array<ResolversTypes['AccountInfo']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1200,6 +1026,7 @@ export type Resolvers<ContextType = any> = {
   BountyStatus?: BountyStatusResolvers<ContextType>;
   ChainInfo?: ChainInfoResolvers<ContextType>;
   CollectiveProposal?: CollectiveProposalResolvers<ContextType>;
+  Conviction?: ConvictionResolvers<ContextType>;
   Council?: CouncilResolvers<ContextType>;
   CouncilCandidate?: CouncilCandidateResolvers<ContextType>;
   CouncilMember?: CouncilMemberResolvers<ContextType>;
@@ -1234,3 +1061,4 @@ export type Resolvers<ContextType = any> = {
   TreasurySummary?: TreasurySummaryResolvers<ContextType>;
   ValidatorsGroup?: ValidatorsGroupResolvers<ContextType>;
 };
+

--- a/subschemas/substrate-api-proxy/src/resolvers/Query/convictions.ts
+++ b/subschemas/substrate-api-proxy/src/resolvers/Query/convictions.ts
@@ -1,0 +1,38 @@
+import type { Conviction } from '../../generated/resolvers-types';
+import type { Context } from '../../types';
+
+import BN from 'bn.js';
+import { BN_THOUSAND } from '@polkadot/util';
+import { getBlockTime } from '../../services/relayChainService';
+
+const CONVICTIONS: number[] = [1, 2, 4, 8, 16, 32];
+const SEC_DAY = 60 * 60 * 24;
+
+export async function convictions(
+  _: Record<string, never>,
+  __: Record<string, never>,
+  { api }: Context,
+) {
+  const { blockTime } = getBlockTime(api);
+
+  return [
+    { text: '0.1x voting balance, no lockup period', value: 0 },
+    ...CONVICTIONS.map((lock, index): Conviction => {
+      const value = index + 1;
+      const bnLock = new BN(lock);
+      const period = (
+        bnLock
+          .mul(
+            api.consts.democracy.enactmentPeriod
+              .muln(blockTime)
+              .div(BN_THOUSAND),
+          )
+          .toNumber() / SEC_DAY
+      ).toFixed(2);
+      return {
+        text: `${value}x voting balance, locked for ${lock}x enactment (${period} days)`,
+        value,
+      };
+    }),
+  ];
+}

--- a/subschemas/substrate-api-proxy/src/resolvers/Query/convictions.ts
+++ b/subschemas/substrate-api-proxy/src/resolvers/Query/convictions.ts
@@ -3,7 +3,7 @@ import type { Context } from '../../types';
 
 import BN from 'bn.js';
 import { BN_THOUSAND } from '@polkadot/util';
-import { getBlockTime } from '../../services/relayChainService';
+import { getBlockTime } from '../../services/substrateChainService';
 
 const CONVICTIONS: number[] = [1, 2, 4, 8, 16, 32];
 const SEC_DAY = 60 * 60 * 24;

--- a/subschemas/substrate-api-proxy/src/resolvers/Query/democracy.ts
+++ b/subschemas/substrate-api-proxy/src/resolvers/Query/democracy.ts
@@ -6,7 +6,7 @@ import {Context} from '../../types';
 import {getCallParams, formatCallMeta} from '../../utils/call';
 import {notEmpty} from '../../utils/notEmpty';
 import {BN_ONE} from '@polkadot/util';
-import {getBlockTime} from '../../services/relayChainService';
+import {getBlockTime} from '../../services/substrateChainService';
 
 interface ProposalInfo extends Omit<Proposal, 'seconds'> {
   seconds: PartialProposalSecond[];

--- a/subschemas/substrate-api-proxy/src/resolvers/Query/events.ts
+++ b/subschemas/substrate-api-proxy/src/resolvers/Query/events.ts
@@ -1,5 +1,5 @@
 import {Context} from '../../types';
-import {getBlockTime} from '../../services/relayChainService';
+import {getBlockTime} from '../../services/substrateChainService';
 import {BN, BN_ONE, formatNumber} from '@polkadot/util';
 import {BlockNumber, LeasePeriodOf} from '@polkadot/types/interfaces';
 import {u32} from '@polkadot/types';

--- a/subschemas/substrate-api-proxy/src/resolvers/Query/index.ts
+++ b/subschemas/substrate-api-proxy/src/resolvers/Query/index.ts
@@ -12,34 +12,36 @@ import {
   democracyReferendums,
   democracyReferendum,
 } from './democracy';
+import {crowdloanSummary} from './crowdloan';
 import {treasurySummary, treasury} from './treasury';
 import {councilMotions} from './councilMotions';
 import {registrars} from './registrars';
 import moduleElection from './moduleElection';
 import {parachainsInfo} from './parachains';
-import {crowdloanSummary} from './crowdloan';
+import {convictions} from './convictions';
 
 export const Query = {
-  balance,
-  chainInfo,
-  tip,
-  tips,
-  council,
-  councilMotions,
   account,
+  balance,
   bountiesSummary,
   bounties,
   bounty,
-  events,
+  chainInfo,
+  council,
+  councilMotions,
+  convictions,
+  crowdloanSummary,
   democracySummary,
   democracyProposals,
   democracyProposal,
   democracyReferendums,
   democracyReferendum,
-  treasurySummary,
-  treasury,
-  registrars,
+  events,
   moduleElection,
   parachainsInfo,
-  crowdloanSummary,
+  registrars,
+  tip,
+  tips,
+  treasurySummary,
+  treasury,
 };

--- a/subschemas/substrate-api-proxy/src/services/parachainsService.ts
+++ b/subschemas/substrate-api-proxy/src/services/parachainsService.ts
@@ -5,7 +5,7 @@ import type {LeasePeriod} from '../generated/resolvers-types';
 import type {Context} from '../types';
 
 import {BN_ZERO, formatNumber, BN_ONE, BN_HUNDRED} from '@polkadot/util';
-import {getBlockTime} from '../services/relayChainService';
+import {getBlockTime} from '../services/substrateChainService';
 
 type ParaIdEntries = [StorageKey<[ParaId]>, Option<PolkadotRuntimeParachainsParasParaLifecycle>][];
 

--- a/subschemas/substrate-api-proxy/src/services/substrateChainService.ts
+++ b/subschemas/substrate-api-proxy/src/services/substrateChainService.ts
@@ -1,14 +1,54 @@
 import type BN from 'bn.js';
 
 import {Compact} from '@polkadot/types';
+import {BlockNumber} from '@polkadot/types/interfaces';
 import {Registry} from '@polkadot/types/types';
-import {formatBalance as format} from '@polkadot/util';
+import {formatBalance as format, BN as Bn, BN_ONE, extractTime} from '@polkadot/util';
 import {Context} from '../types';
 
 type Balance = Compact<any> | BN | string | number;
 
+type BlockTimeResult = {
+  blockTime: number;
+  timeStringParts: string[];
+  formattedTime: string;
+};
+
 // for million, 2 * 3-grouping + comma
 const M_LENGTH = 6 + 1;
+
+const DEFAULT_TIME = new Bn(6000);
+
+export function getBlockTime(api: Context['api'], blockNumber: BlockNumber | BN = BN_ONE): BlockTimeResult {
+  if (!blockNumber) {
+    return {
+      blockTime: DEFAULT_TIME.toNumber(),
+      timeStringParts: [],
+      formattedTime: '',
+    };
+  }
+
+  const blockTime =
+    api.consts.babe?.expectedBlockTime ||
+    api.consts.difficulty?.targetBlockTime ||
+    api.consts.timestamp?.minimumPeriod.muln(2) ||
+    DEFAULT_TIME;
+
+  const {days, hours, minutes, seconds} = extractTime(Math.abs(blockTime.mul(blockNumber).toNumber()));
+
+  const timeStr = [
+    days ? (days > 1 ? `${days} days` : '1 day') : null,
+    hours ? (hours > 1 ? `${hours} hrs` : '1 hr') : null,
+    minutes ? (minutes > 1 ? `${minutes} mins` : '1 min') : null,
+    seconds ? (seconds > 1 ? `${seconds} s` : '1 s') : null,
+  ].filter((value): value is string => !!value);
+
+  return {
+    blockTime: blockTime.toNumber(),
+    timeStringParts: timeStr,
+    formattedTime: timeStr.filter(Boolean).slice(0, 2).join(' '),
+  };
+}
 
 export function formatBalance(api: Context['api'], value: Balance, isShort?: boolean): string {
   const {decimals, token} = getFormat(api.registry);

--- a/subschemas/substrate-api-proxy/src/typeDefs/convictions.ts
+++ b/subschemas/substrate-api-proxy/src/typeDefs/convictions.ts
@@ -1,0 +1,10 @@
+export default /* GraphQL */ `
+  type Conviction {
+    text: String!
+    value: Int!
+  }
+
+  type Query {
+    convictions: [Conviction!]
+  }
+`;

--- a/subschemas/substrate-api-proxy/src/typeDefs/index.ts
+++ b/subschemas/substrate-api-proxy/src/typeDefs/index.ts
@@ -11,6 +11,7 @@ import registrars from './registrars';
 import moduleElection from './moduleElection';
 import parachains from './parachains';
 import crowdLoan from './crowdloan';
+import convictions from './convictions';
 
 export default [
   chainInfo,
@@ -26,4 +27,5 @@ export default [
   moduleElection,
   parachains,
   crowdLoan,
+  convictions,
 ];

--- a/subschemas/substrate-api-proxy/src/typeDefs/index.ts
+++ b/subschemas/substrate-api-proxy/src/typeDefs/index.ts
@@ -14,18 +14,19 @@ import crowdLoan from './crowdloan';
 import convictions from './convictions';
 
 export default [
-  chainInfo,
-  tips,
-  council,
   account,
   balance,
-  events,
   bounties,
+  chainInfo,
+  council,
+  convictions,
+  crowdLoan,
   democracy,
-  treasury,
-  registrars,
+  events,
   moduleElection,
   parachains,
-  crowdLoan,
   convictions,
+  registrars,
+  tips,
+  treasury,
 ];


### PR DESCRIPTION
- Adds typeDefs and resolver.
- Organizing typeDefs alphabetically.
- Removing `ralayChainService` in favor of `substrateChainService`.
- Prettier formatting.

Fixes #57 